### PR TITLE
Optimise for trade off between round and square display

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -62,9 +62,9 @@ Application {
             verticalCenter: parent.verticalCenter
             verticalCenterOffset: -parent.height * 0.002
             left: parent.left
-            leftMargin: parent.width * 0.159
+            leftMargin: Dims.w(15.9)
             right: parent.right
-            rightMargin: parent.width * 0.016
+            rightMargin: Dims.w(1.6)
         }
         height: Dims.h(70)
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2016 - Sylvia van Os <iamsylvie@openmailbox.org>
+ * Copyright (C) 2021 Timo Könnecke <github.com/eLtMosen>
+ *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
  *               2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -57,26 +58,33 @@ Application {
 
     Row {
         anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenterOffset: -parent.height * 0.002
         anchors.left: parent.left
+        anchors.leftMargin: parent.width * 0.159
+
         anchors.right: parent.right
+        anchors.rightMargin: parent.width * 0.016
+
         height: Dims.h(70)
+
         Spinner {
             id: hourLV
             currentIndex: 0
             enabled: !timer.running
             height: parent.height
-            width: Dims.w(20)
-            model: 10
-            delegate: SpinnerDelegate { text: index }
+            width: parent.width * 0.165
+            model: 24
+            delegate: SpinnerDelegate { text: zeroPad(index) }
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex
         }
 
         Label {
             text: ":"
             anchors.verticalCenter: parent.verticalCenter
+            anchors.verticalCenterOffset: -parent.height * 0.013
             horizontalAlignment: Text.AlignHCenter
-            width: Dims.w(20)
-            font.pixelSize: Dims.l(12)
+            width: parent.width * 0.165
+            font.pixelSize: Dims.l(9)
         }
 
         Spinner {
@@ -84,7 +92,7 @@ Application {
             currentIndex: 5
             enabled: !timer.running
             height: parent.height
-            width: Dims.w(20)
+            width: parent.width * 0.165
             model: 60
             highlightMoveDuration: currentIndex != 0 ? 400 : 0
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex
@@ -93,9 +101,10 @@ Application {
         Label {
             text: ":"
             anchors.verticalCenter: parent.verticalCenter
+            anchors.verticalCenterOffset: -parent.height * 0.013
             horizontalAlignment: Text.AlignHCenter
-            width: Dims.w(20)
-            font.pixelSize: Dims.l(12)
+            width: parent.width * 0.165
+            font.pixelSize: Dims.l(9)
         }
 
         Spinner {
@@ -103,7 +112,7 @@ Application {
             currentIndex: 0
             enabled: !timer.running
             height: parent.height
-            width: Dims.w(20)
+            width: parent.width * 0.165
             model: 60
             highlightMoveDuration: currentIndex != 0 ? 400 : 0
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2021 Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
+ *               2016 Sylvia van Os <iamsylvie@openmailbox.org>
+ *               2015 Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,14 +57,15 @@ Application {
     }
 
     Row {
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: -parent.height * 0.002
-        anchors.left: parent.left
-        anchors.leftMargin: parent.width * 0.159
-
-        anchors.right: parent.right
-        anchors.rightMargin: parent.width * 0.016
-
+        id: mainRow
+        anchors {
+            verticalCenter: parent.verticalCenter
+            verticalCenterOffset: -parent.height * 0.002
+            left: parent.left
+            leftMargin: parent.width * 0.159
+            right: parent.right
+            rightMargin: parent.width * 0.016
+        }
         height: Dims.h(70)
 
         Spinner {
@@ -72,19 +73,10 @@ Application {
             currentIndex: 0
             enabled: !timer.running
             height: parent.height
-            width: parent.width * 0.165
+            width: parent.width * 0.16
             model: 24
             delegate: SpinnerDelegate { text: zeroPad(index) }
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex
-        }
-
-        Label {
-            text: ":"
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: -parent.height * 0.013
-            horizontalAlignment: Text.AlignHCenter
-            width: parent.width * 0.165
-            font.pixelSize: Dims.l(9)
         }
 
         Spinner {
@@ -92,19 +84,10 @@ Application {
             currentIndex: 5
             enabled: !timer.running
             height: parent.height
-            width: parent.width * 0.165
+            width: parent.width * 0.505
             model: 60
             highlightMoveDuration: currentIndex != 0 ? 400 : 0
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex
-        }
-
-        Label {
-            text: ":"
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: -parent.height * 0.013
-            horizontalAlignment: Text.AlignHCenter
-            width: parent.width * 0.165
-            font.pixelSize: Dims.l(9)
         }
 
         Spinner {
@@ -112,11 +95,50 @@ Application {
             currentIndex: 0
             enabled: !timer.running
             height: parent.height
-            width: parent.width * 0.165
+            width: parent.width * 0.16
             model: 60
             highlightMoveDuration: currentIndex != 0 ? 400 : 0
             onCurrentIndexChanged: if(enabled) seconds = secondLV.currentIndex + 60*minuteLV.currentIndex + 3600*hourLV.currentIndex
         }
+    }
+
+    Label {
+        text: "h"
+        anchors {
+            centerIn: app
+            verticalCenterOffset: -app.height * 0.056
+            horizontalCenterOffset: -app.width * 0.199
+        }
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: Dims.l(6.4)
+        font.styleName: "Medium"
+        opacity:0.9
+    }
+
+    Label {
+        text: "m"
+        anchors {
+            centerIn: app
+            verticalCenterOffset: -app.height * 0.056
+            horizontalCenterOffset: app.width * 0.084
+        }
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: Dims.l(6.4)
+        font.styleName: "Medium"
+        opacity:0.9
+    }
+
+    Label {
+        text: "s"
+        anchors {
+            centerIn: app
+            verticalCenterOffset: -app.height * 0.056
+            horizontalCenterOffset: app.width * 0.343
+        }
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: Dims.l(6.4)
+        font.styleName: "Medium"
+        opacity:0.9
     }
 
     IconButton {


### PR DESCRIPTION
The presentation and usability on round display was suboptimal due to hour and second Spinner being located very close to the rim of round watches making input hard due to the finger colliding with the rim.
The aim is to have a layout that fits both, square and round displays.
Important, please review on device and test wether the width of the Spinners is still sufficient for convenient finger operation.

- Center `Row` elements to 1/5th of the app.width to have equal spacing between rim-left - > hour -> minute -> second -> rim-right
- Correct divider `:` verticalOffset to perfectly vertical center and changed size to visually fit with the other secondary elements (namely the not current Spinner items).
- Employed formerly unused `function zeroPad(n)` to pad the hour Spinner to aid with equal horizontal spacing.
- Extended hour model to 24 to be able to set a timer for the day, not only 9 hours.

Visual Change before and after commit:

https://user-images.githubusercontent.com/15074193/145403585-26c205cc-f1a5-445b-b508-d05426040825.mp4

- Make design more AOS like by adapting the h m s indicators from the stopwatch

Visual Change after commit https://github.com/AsteroidOS/asteroid-timer/pull/10/commits/cecf4f50d3e7efcd61821bcca81a31824160c669

![appdrawer-000-timer-space-hms8](https://user-images.githubusercontent.com/15074193/145462524-1a951df4-adda-45d2-a061-af634629c660.jpg)

