### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ ecm_find_qmlmodule(Nemo.Alarms 1.0)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-timer.in
+	${CMAKE_BINARY_DIR}/asteroid-timer
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-timer
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-timer)
 

--- a/asteroid-timer.desktop.template
+++ b/asteroid-timer.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-timer
+Exec=asteroid-timer
 Icon=ios-timer-outline
 X-Asteroid-Center-Color=#A6005F
 X-Asteroid-Outer-Color=#0C0003

--- a/asteroid-timer.in
+++ b/asteroid-timer.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-timer.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-timer main.cpp resources.qrc)
-set_target_properties(asteroid-timer PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-timer PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-timer PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-timer
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker