### PR TITLE
Set timer title to be duration interval

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -166,7 +166,7 @@ Application {
                 alarmObject = alarmModel.createAlarm()
                 alarmObject.countdown = true
                 alarmObject.second = seconds-1
-                alarmObject.title = "";
+                alarmObject.title = new Date(seconds).toISOString().slice(11, 19);
                 alarmObject.enabled = true
                 alarmObject.save()
 


### PR DESCRIPTION
Rather than having the duration interval show "00:00" when the timer expires, this sets the title to the desired time in HH:MM:SS format.  To be effective, this is matched with a corresponding change in asteroid-alarmclock in the alarm presenter.  This is part of a solution to #19.