### PR TITLE
Fix title setting

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -166,7 +166,7 @@ Application {
                 alarmObject = alarmModel.createAlarm()
                 alarmObject.countdown = true
                 alarmObject.second = seconds-1
-                alarmObject.title = new Date(seconds).toISOString().slice(11, 19);
+                alarmObject.title = new Date(seconds*1000).toISOString().slice(11, 19);
                 alarmObject.enabled = true
                 alarmObject.save()
 


### PR DESCRIPTION
The Date() constructor takes milliseconds as an argument and not seconds.  This fixes that oversight.