### PR TITLE
Handle countdown alarm dialogs in-app to prevent app closing (fixes #21)

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -21,6 +21,7 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 import Nemo.Configuration 1.0
 import Nemo.Alarms 1.0
+import Nemo.Ngf 1.0
 
 Application {
     id: app
@@ -32,6 +33,10 @@ Application {
     property var startDate: 0
     property int selectedTime: 0
     property int seconds: 5*60
+    property bool alarmActive: false
+    property var alarmDialog: null
+
+    overridesSystemGestures: alarmActive
 
     function zeroPad(n) {
         return (n < 10 ? "0" : "") + n
@@ -43,10 +48,29 @@ Application {
         defaultValue: 5*60
     }
 
+    AlarmHandler {
+        id: alarmHandler
+        onActiveDialogsChanged: {
+            if (!alarmActive && activeDialogs.length > 0 && activeDialogs[0].type === Alarm.Countdown) {
+                alarmDialog = activeDialogs[0]
+                alarmActive = true
+                dialogOnScreen = true
+                feedback.play()
+            }
+        }
+    }
+
+    NonGraphicalFeedback {
+        id: feedback
+        event: "alarm"
+    }
+
     AlarmsModel {
         id: alarmModel
         onlyCountdown: true
         onPopulatedChanged: {
+            if (alarmActive) return
+            var foundAlarm = false
             for (var i=0; rowCount() > i; i++) {
                 // Get Alarm object using AlarmObjectRole(=0x0100)
                 var alarm = alarmModel.data(alarmModel.index(i, 0), 0x0100)
@@ -58,7 +82,12 @@ Application {
                     seconds = alarm.triggerTime - (startDate.getTime()/1000)
                     selectedTime = seconds
                     timer.start()
+                    foundAlarm = true
                 }
+            }
+            if (!foundAlarm) {
+                alarmObject = null
+                seconds = lastTimerDuration.value
             }
         }
     }
@@ -192,6 +221,77 @@ Application {
                 secondLV.currentIndex = seconds%60
                 minuteLV.currentIndex = (seconds%3600)/60
                 hourLV.currentIndex = seconds/3600
+            }
+        }
+    }
+
+    Item {
+        id: alarmOverlay
+        visible: alarmActive
+        anchors.fill: parent
+        z: 100
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#333333"
+        }
+
+        StatusPage {
+            icon: "ios-timer-outline"
+        }
+
+        Label {
+            id: alarmTitle
+            height: Dims.h(44)
+            width: Dims.l(62)
+            anchors {
+                bottom: parent.bottom
+                horizontalCenter: parent.horizontalCenter
+            }
+            renderType: Text.NativeRendering
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.WordWrap
+            font.pixelSize: Dims.l(8)
+            text: alarmDialog ? alarmDialog.title : ""
+        }
+
+        IconButton {
+            id: alarmDismiss
+            iconName: "ios-checkmark-circle-outline"
+            anchors {
+                left: parent.left
+                verticalCenter: parent.verticalCenter
+                leftMargin: Dims.iconButtonMargin
+            }
+            onClicked: {
+                feedback.stop()
+                if(alarmDialog) {
+                    alarmDialog.dismiss()
+                }
+                alarmHandler.dialogOnScreen = false
+                alarmActive = false
+                alarmObject = null
+                seconds = lastTimerDuration.value
+            }
+        }
+
+        IconButton {
+            id: alarmRepeat
+            iconName: "ios-refresh-circle-outline"
+            anchors {
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                rightMargin: Dims.iconButtonMargin
+            }
+            onClicked: {
+                feedback.stop()
+                if(alarmDialog) {
+                    alarmDialog.enabled = true
+                    alarmDialog.save()
+                }
+                alarmHandler.dialogOnScreen = false
+                alarmActive = false
             }
         }
     }


### PR DESCRIPTION
When the timer alarm fires, the system launches alarmpresenter (a separate app) to show the alarm dialog. When the user dismisses or repeats the alarm, alarmpresenter closes its window and the compositor returns to the home screen instead of the timer app. The user must manually find and reopen the timer for each use.

This change adds in-app alarm handling using AlarmHandler:

- Intercepts the countdown alarm before the external alarmpresenter is launched by setting dialogOnScreen = true
- Shows an in-app overlay with OK and Repeat buttons matching the alarmpresenter design
- On dismiss: resets the timer to its setup state so another timer can be started immediately
- On repeat: re-enables the countdown alarm to restart the timer with the same duration
- Adds haptic feedback (NonGraphicalFeedback) when the alarm fires
- Disables system gestures during the alarm to prevent accidental dismissal

Fixes #21