### PR TITLE
Use asteroid-qt6 booster type for proper QML pre-warming

### DIFF
--- a/asteroid-timer.in
+++ b/asteroid-timer.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qt6 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-timer.so
+exec invoker --single-instance --type=asteroid-qt6 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-timer.so


### PR DESCRIPTION
The mapplauncherd-booster-asteroid registers as booster type asteroid-qt6 (see mapplauncherd-booster-asteroid/src/qmlbooster.cpp); when invoker is asked for --type=qt6 it hits the upstream mapplauncherd-qt booster instead, which is a no-op preload that defeats AsteroidOS's per-launch QML pre-warming. End result: every app launch starts with a cold QQmlEngine and runs ~1s slower than it needs to. Switching to --type=asteroid-qt6 routes to the pre-warmed booster as intended.